### PR TITLE
Clarify specifications about custom regulations

### DIFF
--- a/BeatSpeedrun/Source/Controllers/LeaderboardMainViewController.cs
+++ b/BeatSpeedrun/Source/Controllers/LeaderboardMainViewController.cs
@@ -187,10 +187,13 @@ namespace BeatSpeedrun.Controllers
             }
             else
             {
-                _view.FooterText = theme.ReplaceRichText(
-                    $"<$main>{speedrun.Regulation.Title}<$accent> / <$main>" +
-                    (speedrun.Progress.TargetSegment is Progress.SegmentProgress t ? $"{t.Segment}<$accent> / <$main>{t.RequiredPp:0.#}pp" : "endless")
-                );
+                var title = Regulation.IsCustomPath(speedrun.RegulationPath)
+                    ? "<$accent>(custom) <$main>" + speedrun.Regulation.Title
+                    : "<$main>" + speedrun.Regulation.Title;
+                var target = speedrun.Progress.TargetSegment is Progress.SegmentProgress t
+                    ? $"<$main>{t.Segment}<$accent> / <$main>{t.RequiredPp:0.#}pp"
+                    : "<$main>endless";
+                _view.FooterText = theme.ReplaceRichText($"{title}<$accent> / {target}");
             }
         }
 

--- a/BeatSpeedrun/Source/Controllers/SettingsViewController.cs
+++ b/BeatSpeedrun/Source/Controllers/SettingsViewController.cs
@@ -42,12 +42,12 @@ namespace BeatSpeedrun.Controllers
             if (_currentSpeedrunManager.Current is Speedrun speedrun)
             {
                 selectedRegulationOption =
-                    new SettingsView.RegulationOption(speedrun.RegulationId);
+                    new SettingsView.RegulationOption(speedrun.RegulationPath);
                 selectedSegmentOption =
                     speedrun.Progress.TargetSegment is Progress.SegmentProgress s
                         ? new SettingsView.SegmentOption(s.Segment, s.RequiredPp)
                         : SettingsView.SegmentOption.Endless;
-                _selectedRegulation = selectedRegulationOption.Id;
+                _selectedRegulation = selectedRegulationOption.Path;
                 _selectedSegment = selectedSegmentOption?.Segment;
 
                 _view.DescriptionText = speedrun.Regulation.Description;
@@ -77,11 +77,11 @@ namespace BeatSpeedrun.Controllers
                 return;
             }
 
-            selectedRegulationOption = regulationOptions.FirstOrDefault(r => r.Id == _selectedRegulation);
+            selectedRegulationOption = regulationOptions.FirstOrDefault(r => r.Path == _selectedRegulation);
             if (selectedRegulationOption == null)
             {
                 selectedRegulationOption = regulationOptions[0];
-                _selectedRegulation = selectedRegulationOption.Id;
+                _selectedRegulation = selectedRegulationOption.Path;
             }
 
             _view.ReplaceRegulationDropdownChoices(regulationOptions);
@@ -147,7 +147,7 @@ namespace BeatSpeedrun.Controllers
 
         internal void SelectRegulation(SettingsView.RegulationOption option)
         {
-            _selectedRegulation = option.Id;
+            _selectedRegulation = option.Path;
             Render();
         }
 

--- a/BeatSpeedrun/Source/Managers/MapSetManager.cs
+++ b/BeatSpeedrun/Source/Managers/MapSetManager.cs
@@ -15,86 +15,60 @@ namespace BeatSpeedrun.Managers
         private readonly ConcurrentDictionary<string, Task<MapSet>> _mapSets =
             new ConcurrentDictionary<string, Task<MapSet>>();
 
-        internal Task<MapSet> GetAsync(string uriOrRelativePath, CancellationToken ct = default)
+        internal Task<MapSet> GetAsync(string mapSetPath, CancellationToken ct = default)
         {
-            return _mapSets.GetOrAdd(uriOrRelativePath, LoadAsync).WithCancellation(ct);
+            return _mapSets
+                .AddOrUpdate(
+                    mapSetPath,
+                    path => LoadAsync(path),
+                    (path, t) => t.IsFaulted ? LoadAsync(path, TimeSpan.FromSeconds(3)) : t)
+                .WithCancellation(ct);
         }
 
-        private async Task<MapSet> LoadAsync(string uriOrRelativePath)
+        private async Task<MapSet> LoadAsync(string mapSetPath, TimeSpan delay = default)
         {
-            Uri uri;
+            await Task.Delay(delay);
 
             try
             {
-                uri = new Uri(uriOrRelativePath);
-            }
-            catch
-            {
-                uri = null;
-            }
-
-            if (uri != null && (uri.Scheme == "https" || uri.Scheme == "http"))
-            {
-                return await LoadFromWebAsync(uri);
-            }
-
-            var relativePath = uriOrRelativePath.Split('/');
-            if (relativePath.Any(part => part == ".."))
-            {
-                throw new ArgumentException("MapSet path cannot contain '..'");
-            }
-
-            try
-            {
-                return LoadFromCache(relativePath);
-            }
-            catch (Exception ex)
-            {
-                var isIgnorableError = ex is FileNotFoundException || ex is DirectoryNotFoundException;
-                if (!isIgnorableError)
+                if (mapSetPath.StartsWith("https:") || mapSetPath.StartsWith("http:"))
                 {
-                    Plugin.Log.Warn($"Could not load mapset '{string.Join("/", relativePath)}' from cache:\n{ex}");
+                    var uri = new Uri(mapSetPath);
+                    var json = await HttpClient.GetStringAsync(uri);
+                    return MapSet.FromJson(json);
+                }
+
+                if (mapSetPath.StartsWith("custom:"))
+                {
+                    var relativePath = mapSetPath.Substring("custom:".Length).Replace('\\', '/').Split('/');
+                    if (relativePath.Any(part => part == ".."))
+                    {
+                        throw new ArgumentException("Custom MapSet path cannot contain '..'");
+                    }
+                    var filePath = Path.Combine(CustomDirectory, Path.Combine(relativePath));
+                    var json = File.ReadAllText(filePath);
+                    return MapSet.FromJson(json);
+                }
+
+                {
+                    var uri = new Uri(ModProvidedBaseUri + mapSetPath);
+                    var json = await HttpClient.GetStringAsync(uri);
+                    return MapSet.FromJson(json);
                 }
             }
-
-            return await LoadFromRepositoryAsync(relativePath);
-        }
-
-        private async Task<MapSet> LoadFromWebAsync(Uri uri)
-        {
-            var json = await HttpClient.GetStringAsync(uri);
-            // We don't cache mapsets from the web
-            return MapSet.FromJson(json);
-        }
-
-        private MapSet LoadFromCache(string[] relativePath)
-        {
-            // Indeed, you can place your own mapsets in the cache directory
-            var cache = Path.Combine(CacheDirectory, Path.Combine(relativePath));
-            var json = File.ReadAllText(cache);
-            return MapSet.FromJson(json);
-        }
-
-        private async Task<MapSet> LoadFromRepositoryAsync(string[] relativePath)
-        {
-            var uri = new Uri(RepositoryRoot + string.Join("/", relativePath));
-            var json = await HttpClient.GetStringAsync(uri);
-            var mapSet = MapSet.FromJson(json);
-            try
+            catch (OperationCanceledException)
             {
-                var cache = Path.Combine(CacheDirectory, Path.Combine(relativePath));
-                Directory.CreateDirectory(Path.GetDirectoryName(cache));
-                File.WriteAllText(cache, json);
+                throw;
             }
             catch (Exception ex)
             {
-                Plugin.Log.Warn($"Failed to cache mapset '{string.Join("/", relativePath)}':\n{ex}");
+                Plugin.Log.Warn($"Could not load mapset '{mapSetPath}':\n{ex}");
+                throw;
             }
-            return mapSet;
         }
 
-        private static readonly string CacheDirectory = Path.Combine(Environment.CurrentDirectory, "UserData", "BeatSpeedrun", "MapSets");
-        private static readonly string RepositoryRoot = "https://raw.githubusercontent.com/acc-is-sponge/beat-speedrun-mapsets/main/";
+        private static readonly string CustomDirectory = Path.Combine(Environment.CurrentDirectory, "UserData", "BeatSpeedrun", "CustomMapSets");
+        private static readonly string ModProvidedBaseUri = "https://raw.githubusercontent.com/acc-is-sponge/beat-speedrun-mapsets/main/";
         private static readonly HttpClient HttpClient = new HttpClient();
     }
 }

--- a/BeatSpeedrun/Source/Managers/SpeedrunManager.cs
+++ b/BeatSpeedrun/Source/Managers/SpeedrunManager.cs
@@ -21,11 +21,11 @@ namespace BeatSpeedrun.Managers
         }
 
         internal async Task<Speedrun> CreateAsync(
-            string regulationUrlOrPath,
+            string regulationPath,
             Segment? targetSegment,
             CancellationToken ct)
         {
-            var regulation = await _regulationManager.GetAsync(regulationUrlOrPath, ct);
+            var regulation = await _regulationManager.GetAsync(regulationPath, ct);
             var mapSet = await _mapSetManager.GetAsync(regulation.Rules.MapSet, ct);
 
             var startedAt = DateTime.UtcNow;
@@ -33,7 +33,7 @@ namespace BeatSpeedrun.Managers
             {
                 Id = ((long)(startedAt - UnixEpoch).TotalMilliseconds).ToString(),
                 StartedAt = startedAt,
-                Regulation = regulationUrlOrPath,
+                Regulation = regulationPath,
                 TargetSegment = targetSegment,
                 Checksum = new SnapshotChecksum
                 {

--- a/BeatSpeedrun/Source/Models/Regulation.cs
+++ b/BeatSpeedrun/Source/Models/Regulation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using BeatSpeedrun.Extensions;
 using Newtonsoft.Json;
 
@@ -39,6 +40,41 @@ namespace BeatSpeedrun.Models
             }
             // TODO: more validations
             return regulation;
+        }
+
+        internal static bool IsCustomPath(string path)
+        {
+            return path.StartsWith("http:") || path.StartsWith("https:") || path.StartsWith("custom:");
+        }
+
+        internal static string ShortenPath(string path)
+        {
+            if (path.StartsWith("http:") || path.StartsWith("https:"))
+            {
+                try
+                {
+                    var uri = new Uri(path);
+                    path = uri.LocalPath;
+                }
+                catch (Exception ex)
+                {
+                    Plugin.Log.Warn($"Cannot parse regulation path '{path}' as URI:\n{ex}");
+                    return path;
+                }
+                return path.EndsWith(".json") ? path.Substring(0, path.Length - 5) : path;
+            }
+
+            if (path.StartsWith("custom:"))
+            {
+                path = "(custom) " + path.Substring("custom:".Length);
+                return path.EndsWith(".json") ? path.Substring(0, path.Length - 5) : path;
+            }
+
+            // omit the last part
+            var pathParts = path.Split('/');
+            return 1 < pathParts.Length
+                ? string.Join("/", pathParts.Take(pathParts.Length - 1))
+                : path;
         }
     }
 

--- a/BeatSpeedrun/Source/Models/Speedrun/Speedrun.cs
+++ b/BeatSpeedrun/Source/Models/Speedrun/Speedrun.cs
@@ -10,7 +10,7 @@ namespace BeatSpeedrun.Models.Speedrun
     internal class Speedrun
     {
         internal string Id { get; }
-        internal string RegulationId { get; }
+        internal string RegulationPath { get; }
         internal Regulation Regulation { get; }
         internal MapSet MapSet { get; }
         internal Progress Progress { get; }
@@ -31,7 +31,7 @@ namespace BeatSpeedrun.Models.Speedrun
             _checksum = snapshot.Checksum;
 
             Id = snapshot.Id;
-            RegulationId = snapshot.Regulation;
+            RegulationPath = snapshot.Regulation;
             Regulation = regulation;
             MapSet = mapSet;
             Progress = new Progress(
@@ -69,7 +69,7 @@ namespace BeatSpeedrun.Models.Speedrun
             {
                 Id = Id,
                 StartedAt = Progress.StartedAt,
-                Regulation = RegulationId,
+                Regulation = RegulationPath,
                 TargetSegment = Progress.TargetSegment?.Segment,
                 Checksum = _checksum,
                 SongScores = SongScores.Select(score => score.Source).ToList(),

--- a/BeatSpeedrun/Source/PluginConfig.cs
+++ b/BeatSpeedrun/Source/PluginConfig.cs
@@ -17,17 +17,10 @@ namespace BeatSpeedrun
         public virtual string CurrentSpeedrun { get; set; }
 
         /// <summary>
-        /// List of regulations. Each string must be an URI or a relative path to the regulation
-        /// JSON from regulations repository (https://github.com/acc-is-sponge/beat-speedrun-regulations).
-        /// For example, `scoresaber/092023.json` denotes the regulation defined in
-        /// https://github.com/acc-is-sponge/beat-speedrun-regulations/blob/main/scoresaber/092023.json.
-        /// Notice that, since this MOD automatically fetches latest regulations from
-        /// https://github.com/acc-is-sponge/beat-speedrun-regulations/blob/main/latest-regulations.json,
-        /// we usually don't need to specify this option. Specifying this option disables the automatic fetching.
+        /// List of custom regulation URIs. Each string must be an URI.
         /// </summary>
-        ///
         [UseConverter(typeof(ListConverter<string>))]
-        public virtual List<string> RegulationOptions { get; set; }
+        public virtual List<string> RegulationUris { get; set; }
 
         public virtual void OnReload()
         {

--- a/BeatSpeedrun/Source/Views/SettingsView.cs
+++ b/BeatSpeedrun/Source/Views/SettingsView.cs
@@ -213,31 +213,16 @@ namespace BeatSpeedrun.Views
 
         internal class RegulationOption
         {
-            internal string Id { get; }
+            internal string Path { get; }
             internal string Label { get; }
 
-            internal RegulationOption(string id)
+            internal RegulationOption(string path)
             {
-                Id = id;
-                Label = ToLabel(id);
+                Path = path;
+                Label = Regulation.ShortenPath(path);
             }
 
             public override string ToString() => Label;
-
-            private static string ToLabel(string id)
-            {
-                // NOTE: Perhaps there is a better way
-                try
-                {
-                    var uri = new Uri(id);
-                    id = uri.LocalPath;
-                }
-                catch
-                {
-                    // ignored
-                }
-                return id.EndsWith(".json") ? id.Substring(0, id.Length - 5) : id;
-            }
 
             internal static readonly RegulationOption Loading = new RegulationOption("...");
         }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ In additions to regulations, a set of difficulty rating for each map is defined 
 
 By default, this MOD fetches the current, up-to-date regulations from these repositories and lists them on the `BEAT SPEEDRUN` tab.
 
+## How to use custom regulations
+
+#### Use custom regulation files
+
+Put your regulation files into `$(BeatSaberDir)/UserData/BeatSpeedrun/CustomRegulations/`
+
+#### Use online custom regulations
+
+Add URIs to `RegulationUris` in `$(BeatSaberDir)/UserData/BeatSpeedrun.json`
+
 ## Credits
 
 - Thanks to [FaZPi](https://twitter.com/FaZ_Pi), [hatopop](https://github.com/hatopopvr) for testing!


### PR DESCRIPTION
closes #4 

### Custom regulations (regulations that are not provided by MOD) are highlighted:
![image](https://github.com/acc-is-sponge/beat-speedrun-mod/assets/143513181/a4acff87-8a8a-4b6d-a96f-eb93ea8af5fe)

### We use `$(BeatSaberDir)/UserData/BeatSpeedrun/{CustomRegulations,CustomMapSets}` directories for custom {regulations,mapsets}.

- This MOD automatically collects custom regulations from `$(BeatSaberDir)/UserData/BeatSpeedrun/CustomRegulations`
- `custom:` prefix is required for `rules.mapSet` setting in the regulation file: https://github.com/acc-is-sponge/beat-speedrun-regulations/commit/f897cc8582cdefdb025bae3df265a85866be8820

### Don't cache MOD-provided regulations/mapsets anymore

`$(BeatSaberDir)/UserData/BeatSpeedrun/{MapSets,Regulations}` are no longer used.
