### PR TITLE
Fix for 1.31.1

### DIFF
--- a/BeatSpeedrun/Source/Extensions/BSMLExtensions.cs
+++ b/BeatSpeedrun/Source/Extensions/BSMLExtensions.cs
@@ -79,8 +79,7 @@ namespace BeatSpeedrun.Extensions
 
         public virtual void Dispose()
         {
-            if (GameplaySetup.IsSingletonAvailable && BSMLParser.IsSingletonAvailable)
-                GameplaySetup.instance.RemoveTab(TabName);
+            GameplaySetup.instance.RemoveTab(TabName);
         }
     }
 }

--- a/BeatSpeedrun/Source/Managers/LevelPlayManager.cs
+++ b/BeatSpeedrun/Source/Managers/LevelPlayManager.cs
@@ -5,6 +5,7 @@ using BeatSpeedrun.Models.Speedrun;
 using Zenject;
 using BeatSpeedrun.Models;
 using System.Threading.Tasks;
+using IPA.Utilities;
 
 namespace BeatSpeedrun.Managers
 {
@@ -106,7 +107,7 @@ namespace BeatSpeedrun.Managers
                     return;
                 }
 
-                var defaultEnvironment = _customLevelLoader.LoadEnvironmentInfo(null, false);
+                var defaultEnvironment = FieldAccessor<CustomLevelLoader, EnvironmentInfoSO>.Get(_customLevelLoader, "_defaultEnvironmentInfo");
                 var beatmapData = await so.difficultyBeatmap.GetBeatmapDataAsync(defaultEnvironment, _playerDataModel.playerData.playerSpecificSettings);
 
                 var maxScore = ScoreModel.ComputeMaxMultipliedScoreForBeatmap(beatmapData);

--- a/BeatSpeedrun/Source/Models/Speedrun/SongScore.cs
+++ b/BeatSpeedrun/Source/Models/Speedrun/SongScore.cs
@@ -74,6 +74,7 @@ namespace BeatSpeedrun.Models.Speedrun
             public EnvironmentInfoSO environmentInfo => null;
             public EnvironmentInfoSO allDirectionsEnvironmentInfo => null;
             public IReadOnlyList<PreviewDifficultyBeatmapSet> previewDifficultyBeatmapSets => null;
+            public EnvironmentInfoSO[] environmentInfos => null;
             public Task<UnityEngine.Sprite> GetCoverImageAsync(CancellationToken _) => Task.FromResult<UnityEngine.Sprite>(null);
         }
 


### PR DESCRIPTION
Support Beat Saber v1.31.1.
I can't test from 1.29.4 to 1.31.0, as the core mods seemed to be unstable, at least in my environment.
For builds prior to 1.29.1, it seems that you need to build in a 1.29.1 environment.
For your information, if you use build artifacts from the 1.31.1 environment with pre-1.29.1, you will get errors similar to the following.
```
[CRITICAL @ 10:34:52 | UnityEngine] MissingMethodException: void BeatSaberMarkupLanguage.Components.Settings.DropDownListSetting.set_ values(System.Collections.ILL) values(System.Collections.IList)
[CRITICAL @ 10:34:52 | UnityEngine] BeatSpeedrun.Controllers.SettingsViewController.Render () (at <df75b4ff29014cc883cbcac0f3597128>:0)
[CRITICAL @ 10:34:52 | UnityEngine] BeatSpeedrun.Controllers.SettingsViewController.Initialize () (at <df75b4ff29014cc883cbcac0f3597128>:0 )
[CRITICAL @ 10:34:52 | UnityEngine] Zenject.InitializableManager.Initialize () (at <34fd6cc1ee2d4d3d8f9c65e77cc80832>:0)
[CRITICAL @ 10:34:52 | UnityEngine] Rethrow as ZenjectException: Error occurred while initializing IInitializable with type 'SettingsViewController'.
[CRITICAL @ 10:34:52 | UnityEngine] Zenject.InitializableManager.Initialize () (at <34fd6cc1ee2d4d3d8f9c65e77cc80832>:0)
[CRITICAL @ 10:34:52 | UnityEngine] Zenject.MonoKernel.Initialize () (at <34fd6cc1ee2d4d3d8f9c65e77cc80832>:0)
[CRITICAL @ 10:34:52 | UnityEngine] Zenject.MonoKernel.Start () (at <34fd6cc1ee2d4d3d8f9c65e77cc80832>:0)
```
Best regards.